### PR TITLE
feat: add http retry to download chunk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +249,7 @@ dependencies = [
  "futures",
  "openssl",
  "pyo3",
+ "rand",
  "reqwest",
  "tokio",
 ]
@@ -570,6 +582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +663,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ crate-type = ["cdylib"]
 futures = "0.3.25"
 openssl = { version = "0.10.44", features = ["vendored"] }
 pyo3 = { version = "0.17.3", features = ["extension-module"] }
+rand = "0.8"
 reqwest = "0.11.13"
 tokio = { version = "1.23.0", features = ["rt", "rt-multi-thread", "fs"] }

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,0 +1,46 @@
+use rand::{thread_rng, Rng};
+use reqwest::{RequestBuilder, Response};
+use std::time::Duration;
+use tokio::time::sleep;
+
+#[derive(Debug)]
+pub enum HttpError {
+    RequestError { status_code: u16 },
+    InvalidRequestBuilder,
+}
+
+fn jitter() -> u32 {
+    thread_rng().gen_range(0..=500)
+}
+
+pub fn exponential_backoff(base_wait_time: u32, n: u32, max: u32) -> u32 {
+    base_wait_time + n.pow(2) + jitter().min(max)
+}
+
+pub async fn retry_http(
+    request: RequestBuilder,
+    max_retries: u32,
+    validate_response: impl Fn(&Response) -> bool,
+) -> Result<Response, HttpError> {
+    let mut result = None;
+    for i in 1..=max_retries {
+        let http_call = request
+            .try_clone()
+            .ok_or(HttpError::InvalidRequestBuilder)?;
+        let r = http_call.send().await;
+        match r {
+            Ok(res) if validate_response(&res) => return Ok(res),
+            Ok(res) => result = Some(res),
+            Err(err) => (), // error!(
+                            // err_msg = err.to_string(),
+                            // "Probably a network error, retrying"
+                            // ),
+        }
+        let wait_time = exponential_backoff(300, i, 2000);
+        // warn!(retry_in = wait_time, "unexpected response status or error");
+        sleep(Duration::from_millis(wait_time.into())).await;
+    }
+    Err(HttpError::RequestError {
+        status_code: result.map(|res| res.status().as_u16()).unwrap_or(0),
+    })
+}


### PR DESCRIPTION
In our repo scanner, I have an http retry helper that might be useful for hf transfer.

I've left the log calls in comment to discuss wether there should be any logging by hf transfer or not while we're at it.

Lmk what you think, no hard feelings if this should be merged or not, thought it might be interesting to have it there :)