### PR TITLE
add metadata pointing to the project home page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,5 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
-
+[project.urls]
+Homepage = "https://github.com/huggingface/hf_transfer"


### PR DESCRIPTION
Including these links in the project file will ensure that pypi.org
links from the project page to the github page. This makes it easier
for someone discovering the project on pypi.org (likely as a
dependency of something else) to find the source for the project.