### PR TITLE
pyproject: add project description and project urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ build-backend = "maturin"
 
 [project]
 name = "hf_transfer"
+description = "Speed up file transfers with the Hugging Face Hub."
+readme = "README.md"
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",
@@ -11,4 +13,6 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
-
+[project.urls]
+Issues = "https://github.com/huggingface/hf_transfer/issues"
+Source = "https://github.com/huggingface/hf_transfer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,4 @@ classifiers = [
 
 [project.urls]
 Issues = "https://github.com/huggingface/hf_transfer/issues"
-Source = "https://github.com/huggingface/hf_transfer"
+Repository = "https://github.com/huggingface/hf_transfer.git"


### PR DESCRIPTION
The reason for this is that when going to https://pypi.org/project/hf-transfer/ there's no information about the source repository for the module.
