### PR TITLE
fix: auth header redirect causes errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hf_transfer"
-version = "0.1.7-dev0"
+version = "0.1.7-dev1"
 dependencies = [
  "futures",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hf_transfer"
-version = "0.1.7-dev0"
+version = "0.1.7-dev1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Auth header was forwarded to redirect URL which will cause authentication errors when querying the S3 API directly.