### PR TITLE
refactor: display a better error msg on status error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,9 @@ async fn download_async(
     .header(RANGE, "bytes=0-0")
     .send()
     .await
-    .map_err(|err| PyException::new_err(format!("Error while downloading: {err:?}")))?;
+    .map_err(|err| PyException::new_err(format!("Error while downloading: {err:?}")))?
+    .error_for_status()
+    .map_err(|err| PyException::new_err(err.to_string()))?;
 
     // Only call the final redirect URL to avoid overloading the Hub with requests and also
     // altering the download count


### PR DESCRIPTION
I was getting "No content length" as an error message while investigating a potential issue, which was confusing because it was not the actual error but only a side effect of the status error.

Adding an `.error_for_status()` call on the response object makes things clearer.