### PR TITLE
fix: forward all headers on identical host

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@ async fn download_async(
                 .try_into()
                 .map_err(|err| PyException::new_err(format!("Invalid header value: {err}")))?;
             if name == AUTHORIZATION {
-                auth_token = Some(v);
+                auth_token = Some(value);
             } else {
                 headers.insert(name, value);
             }
@@ -182,7 +182,7 @@ async fn download_async(
     };
 
     let response = if let Some(token) = auth_token.as_ref() {
-        client.get(&url).bearer_auth(token)
+        client.get(&url).header(AUTHORIZATION, token)
     } else {
         client.get(&url)
     }
@@ -203,12 +203,7 @@ async fn download_async(
         == redirected_url.host()
     {
         if let Some(token) = auth_token {
-            headers.insert(
-                AUTHORIZATION,
-                token
-                    .try_into()
-                    .map_err(|err| PyException::new_err(format!("Invalid header value: {err}")))?,
-            );
+            headers.insert(AUTHORIZATION, token);
         }
     }
 


### PR DESCRIPTION
Had conditionally made it so that `Authorization` header was only sent on the first request to the HF Hub and not on the redirect url. This was a mistake as sometimes the redirect url is also `huggingface.co`.

This PR makes hf_transfer only avoid redirection of `Authorization` if the host part of the url is different in the redirect url.

Also refactor the code to use the `Display` trait instead of `Debug` in error messages.