### PR TITLE
fix: use simple_error instead of PyException

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "pyo3",
  "rand",
  "reqwest",
+ "simple-error",
  "tokio",
  "tokio-util",
 ]
@@ -1000,6 +1001,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "simple-error"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2accd2c41a0e920d2abd91b2badcfa1da784662f54fbc47e0e3a51f1e2e1cf"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ rand = "0.8.5"
 reqwest = { version = "0.12.5", features = ["stream"] }
 tokio = { version = "1.38.1", features = ["rt", "rt-multi-thread", "fs"] }
 tokio-util = { version = "0.7", features = ["codec"] }
+simple-error = "0.3.1"


### PR DESCRIPTION
I experienced this tools hanging without any error like #37 #30  and it happened more frequently in poor Internet situation. 
It appears that the `PyException`  type is experiencing performance issues during string conversion, which may lead to blocking of Tokio asynchronous tasks. 
```rust
let parallel_failure_permit = parallel_failures_semaphore.clone().try_acquire_owned().map_err(|err| {
    PyException::new_err(format!(
    "Failed too many failures in parallel ({parallel_failures}): {dlerr} ({err})"  // Here `dlerr` is PyException type
     ))
   })?;
```
This blocking can prevent the timely dropping of semaphores, causing the semaphore pool associated with max_files to be quickly exhausted, ultimately leading to a deadlock in the entire program. 
This PR addresses the issue by changing the return type of the download_chunk function to simple_error to circumvent this problem.