### PR TITLE
Add license file to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "maturin"
 name = "hf_transfer"
 description = "Speed up file transfers with the Hugging Face Hub."
 readme = "README.md"
+license = {file = "LICENSE"}
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
The published wheels on PyPi are missing the license. This PR adds that, see reference https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license