### PR TITLE
tcp_keepalive fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ async fn download_async(
     let client = reqwest::Client::builder()
         // https://github.com/hyperium/hyper/issues/2136#issuecomment-589488526
         .http2_keep_alive_timeout(Duration::from_secs(15))
+        .tcp_keepalive(Duration::from_secs(15))
         .build()
         .unwrap();
 


### PR DESCRIPTION
I believe the current requests are downloaded from http/1, so setting the http/2 only-feature of the crate seems like an odd way to set this feature. 

Feel free to ignore this PR if not helpful.