### PR TITLE
Set minimum supported Rust version to 1.71.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,13 @@ permissions:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          # see rust-version in Cargo.toml
+          - '1.71.1'
+          # latest
+          - 'stable'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/checkout@v4
@@ -32,6 +39,7 @@ jobs:
         with:
           command: develop
           sccache: 'true'
+          rust-toolchain: ${{ matrix.toolchain }}
       - name: Install huggingface_hub dependencies
         run: |
           source .venv/bin/activate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "hf_transfer"
 version = "0.1.9-dev0"
 edition = "2021"
+# Minimum supported Rust version, keep in sync with test.yml
+rust-version = "1.71.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]


### PR DESCRIPTION
Add `rust-version` to Cargo.toml to ensure that `cargo` from Rust >= 1.83 does not bump `Cargo.lock` to file format v4. 1.71.1 is oldest Rust toolchain that can compile the package and its dependencies:

* package `writeable v0.5.5` cannot be built because it requires rustc 1.67 or newer
* package `mio v1.0.3` cannot be built because it requires rustc 1.70 or newer
* package `zerofrom v0.1.5` cannot be built because it requires rustc 1.71.1 or newer

GHA tests are now building+testing with minimum version and latest stable version of the Rust toolchain.

Fixes: #55