### PR TITLE
Add riscv64 build, make Linux wheel build matrix more explicit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,6 +42,9 @@ jobs:
           - runner: ubuntu-22.04
             target: powerpc64le-unknown-linux-gnu
             arch: ppc64le
+          - runner: ubuntu-22.04
+            target: riscv64gc-unknown-linux-gnu
+            arch: riscv64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,17 +25,23 @@ jobs:
       matrix:
         platform:
           - runner: ubuntu-22.04
-            target: x86_64
+            target: x86_64-unknown-linux-gnu
+            arch: x86_64
           - runner: ubuntu-22.04
-            target: x86
+            target: i686-unknown-linux-gnu
+            arch: x86
           - runner: ubuntu-22.04
-            target: aarch64
+            target: aarch64-unknown-linux-gnu
+            arch: aarch64
           - runner: ubuntu-22.04
-            target: armv7
+            target: armv7-unknown-linux-gnueabihf
+            arch: armv7
             # - runner: ubuntu-22.04
-            #   target: s390x
+            #   target: s390x-unknown-linux-gnu
+            #   arch: s390x
           - runner: ubuntu-22.04
-            target: ppc64le
+            target: powerpc64le-unknown-linux-gnu
+            arch: ppc64le
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -76,7 +82,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.platform.arch }}
           path: dist
 
   musllinux:


### PR DESCRIPTION
maturin supports riscv64 cross build, but the arch string and the target toolchain for rustc don't exactly match up (this is also the case for other architectures like ppc64le and x86). To make the riscv64 addition consistent with the others, change the platform list so that arch and target are distinct fields.

Note that this is being done on behalf of the [RISE Project](https://riseproject.dev/) to improve Python ecosystem support on riscv64 platforms.